### PR TITLE
Revert "fix(Caves): replace perlin with simplex"

### DIFF
--- a/src/main/java/org/terasology/caves/CaveFacetProvider.java
+++ b/src/main/java/org/terasology/caves/CaveFacetProvider.java
@@ -21,7 +21,7 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.utilities.procedural.AbstractNoise;
 import org.terasology.utilities.procedural.Noise;
-import org.terasology.utilities.procedural.SimplexNoise;
+import org.terasology.utilities.procedural.PerlinNoise;
 import org.terasology.utilities.procedural.SubSampledNoise;
 import org.terasology.world.generation.ConfigurableFacetProvider;
 import org.terasology.world.generation.Facet;
@@ -43,8 +43,8 @@ public class CaveFacetProvider implements ConfigurableFacetProvider, FacetProvid
 
     @Override
     public void setSeed(long seed) {
-        baseCaveNoise = new SimplexNoise(seed + 2);
-        baseFadeCaveNoise = new SimplexNoise(seed + 3);
+        baseCaveNoise = new PerlinNoise(seed + 2);
+        baseFadeCaveNoise = new PerlinNoise(seed + 3);
     }
 
     @Override
@@ -81,7 +81,7 @@ public class CaveFacetProvider implements ConfigurableFacetProvider, FacetProvid
                         * (
                         Math.max(fadeForSurfaceCutoff, fadeForScale)
                                 // fade caves on a broad scale to stop them from being uniform
-                                // Amount added to the noise value: 1 = prevent all caves.  0 = allow normal simplex.  -1 = all caves
+                                // Amount added to the noise value: 1 = prevent all caves.  0 = allow normal perlin.  -1 = all caves
                                 + Math.max(0f, Math.abs(fadeCaveNoiseValues[facet.getWorldIndex(pos)]) + (2f * (1f - amountOfCaves)) - 1f)
                 );
 


### PR DESCRIPTION
Reverts Terasology/Caves#2
Perlin and Simplex seem to differ in their noise functions. Until we know how to correctly configure Simplex to act like Perlin, this change is reverted and the removed Perlin parts reintroduced and marked as deprecated.