### PR TITLE
feat: Replace the cave generation algorithm.

### DIFF
--- a/src/main/java/org/terasology/caves/CaveFacet.java
+++ b/src/main/java/org/terasology/caves/CaveFacet.java
@@ -25,6 +25,9 @@ public class CaveFacet extends BaseBooleanFieldFacet3D {
         super(targetRegion, border);
     }
 
+    /**
+     * The index of the given position in arrays corresponding to the region this facet covers.
+     */
     public int getWorldIndex(Vector3i pos) {
         return getWorldIndex(pos.x, pos.y, pos.z);
     }

--- a/src/main/java/org/terasology/caves/CaveFacetProvider.java
+++ b/src/main/java/org/terasology/caves/CaveFacetProvider.java
@@ -20,9 +20,10 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.rendering.nui.properties.Range;
 import org.terasology.utilities.procedural.AbstractNoise;
-import org.terasology.utilities.procedural.Noise;
-import org.terasology.utilities.procedural.PerlinNoise;
-import org.terasology.utilities.procedural.SubSampledNoise;
+import org.terasology.utilities.procedural.BrownianNoise3D;
+import org.terasology.utilities.procedural.Noise3D;
+import org.terasology.utilities.procedural.SimplexNoise;
+import org.terasology.utilities.procedural.SubSampledNoise3D;
 import org.terasology.world.generation.ConfigurableFacetProvider;
 import org.terasology.world.generation.Facet;
 import org.terasology.world.generation.FacetProviderPlugin;
@@ -35,233 +36,37 @@ import org.terasology.world.generator.plugin.RegisterPlugin;
 @RegisterPlugin
 @Produces(CaveFacet.class)
 @Requires(@Facet(SurfaceHeightFacet.class))
-public class CaveFacetProvider implements ConfigurableFacetProvider, FacetProviderPlugin {
+public class CaveFacetProvider implements FacetProviderPlugin {
     private CaveFacetProviderConfiguration configuration = new CaveFacetProviderConfiguration();
 
-    Noise baseCaveNoise;
-    Noise baseFadeCaveNoise;
+    SubSampledNoise3D[] caveNoise = new SubSampledNoise3D[2];
 
     @Override
     public void setSeed(long seed) {
-        baseCaveNoise = new PerlinNoise(seed + 2);
-        baseFadeCaveNoise = new PerlinNoise(seed + 3);
+        for(int i=0; i<2; i++) {
+            Noise3D pNoise = new SimplexNoise(seed + 2 + i);
+            BrownianNoise3D bNoise = new BrownianNoise3D(pNoise, 3);
+            bNoise.setPersistence(1.0);
+            SubSampledNoise3D sNoise = new SubSampledNoise3D(bNoise, new Vector3f(0.01f, 0.01f, 0.01f), 4);
+            caveNoise[i] = sNoise;
+        }
     }
 
     @Override
     public void process(GeneratingRegion region) {
-        float width = configuration.width;
-        float height = configuration.height;
-        float gradualIncreaseOverDepth = configuration.gradualIncreaseOverDepth;
-        float amountOfCavesNearSurface = configuration.amountofCavesNearSurface;
-        float sharpSurfaceCutoffDepth = 12;
-        float minDepth = 0;
-        float amountOfCaves = configuration.amountOfCaves;
-        float noiseLevel = configuration.rawAmount;
 
-        // at default settings,  make caves wider than tall.
-        SubSampledNoise caveNoise = new SubSampledNoise(new RidgedNoise(baseCaveNoise, 2), new Vector3f(0.06f * (1f / width), 0.09f * (1f / height), 0.06f * (1f / width)), 4);
-        SubSampledNoise fadeCaveNoise = new SubSampledNoise(baseFadeCaveNoise, new Vector3f(0.006f * (1f / width), 0.006f * (1f / height), 0.006f * (1f / width)), 1);
         CaveFacet facet = new CaveFacet(region.getRegion(), region.getBorderForFacet(CaveFacet.class));
-        SurfaceHeightFacet surfaceHeightFacet = region.getRegionFacet(SurfaceHeightFacet.class);
 
         // get noise in batch for performance reasons.  Getting it by individual position takes 10 times as long
-        float[] caveNoiseValues = caveNoise.noise(facet.getWorldRegion());
-        float[] fadeCaveNoiseValues = fadeCaveNoise.noise(facet.getWorldRegion());
+        float[][] caveNoiseValues = new float[][]{caveNoise[0].noise(facet.getWorldRegion()),caveNoise[1].noise(facet.getWorldRegion())};
 
         for (Vector3i pos : region.getRegion()) {
-            float depth = surfaceHeightFacet.getWorld(pos.x, pos.z) - pos.y;
-            if (depth > minDepth) {
-                float noiseValue = caveNoiseValues[facet.getWorldIndex(pos)];
-                // fade caves out as they reach the surface or above the surface
-                float fadeForSurfaceCutoff = Math.min(1f - amountOfCavesNearSurface, Math.max(0f, 1f - (depth / sharpSurfaceCutoffDepth)));
-                // gradually decrease caves as they get closer to the surface
-                float fadeForScale = Math.max(0f, 1f - (depth / gradualIncreaseOverDepth)) * (1f - amountOfCavesNearSurface);
+            int i = facet.getWorldIndex(pos);
+            float noiseValue = (float) Math.hypot(caveNoiseValues[0][i], caveNoiseValues[1][i]);
 
-                float noiseLevelIncrease = (1f - noiseLevel)
-                        * (
-                        Math.max(fadeForSurfaceCutoff, fadeForScale)
-                                // fade caves on a broad scale to stop them from being uniform
-                                // Amount added to the noise value: 1 = prevent all caves.  0 = allow normal perlin.  -1 = all caves
-                                + Math.max(0f, Math.abs(fadeCaveNoiseValues[facet.getWorldIndex(pos)]) + (2f * (1f - amountOfCaves)) - 1f)
-                );
-
-                facet.setWorld(pos, noiseValue > noiseLevel + noiseLevelIncrease);
-            }
+            facet.setWorld(pos, noiseValue < 0.2);
         }
 
         region.setRegionFacet(CaveFacet.class, facet);
     }
-
-
-    @Override
-    public String getConfigurationName() {
-        return "Caves";
-    }
-
-    @Override
-    public Component getConfiguration() {
-        return configuration;
-    }
-
-    @Override
-    public void setConfiguration(Component configuration) {
-        this.configuration = (CaveFacetProviderConfiguration) configuration;
-    }
-
-    private static class CaveFacetProviderConfiguration implements Component {
-        @Range(min = 0, max = 1f, increment = 0.05f, precision = 2, description = "Amount of Caves")
-        public float amountOfCaves = 0.75f;
-        @Range(min = 0, max = 2f, increment = 0.05f, precision = 2, description = "Width")
-        public float width = 1f;
-        @Range(min = 0, max = 2f, increment = 0.05f, precision = 2, description = "Height")
-        public float height = 1f;
-        @Range(min = 0, max = 1f, increment = 0.05f, precision = 2, description = "Amount of caves near surface")
-        public float amountofCavesNearSurface = 0.5f;
-        @Range(min = 1f, max = 200f, increment = 5f, precision = 0, description = "Gradual increase over depth")
-        public float gradualIncreaseOverDepth = 64f;
-        @Range(min = -1f, max = 1, increment = 0.05f, precision = 2, description = "Raw Amount (use at own risk)")
-        public float rawAmount = 0.3f;
-
-    }
-
-    public static class RidgedNoise extends AbstractNoise {
-
-        /**
-         * Default persistence value
-         */
-        public static final double DEFAULT_PERSISTENCE = 0.836281;
-
-        /**
-         * Default lacunarity value
-         */
-        public static final double DEFAULT_LACUNARITY = 2.1379201;
-
-        private double lacunarity = DEFAULT_LACUNARITY;
-        private double persistence = DEFAULT_PERSISTENCE;
-
-        private int octaves;
-        private float[] spectralWeights;
-        private float scale;                // 1/sum of all weights
-        private final Noise other;
-
-        /**
-         * Initialize with 9 octaves - <b>this is quite expensive, but backwards compatible</b>
-         *
-         * @param other the noise to use as a basis
-         */
-        public RidgedNoise(Noise other) {
-            this(other, 9);
-        }
-
-        /**
-         * @param other   other the noise to use as a basis
-         * @param octaves the number of octaves to use
-         */
-        public RidgedNoise(Noise other, int octaves) {
-            this.other = other;
-            setOctaves(octaves);
-        }
-
-        /**
-         * Returns Ridged noise at the given position.
-         *
-         * @param x Position on the x-axis
-         * @param y Position on the y-axis
-         * @param z Position on the z-axis
-         * @return The noise value in the range of the base noise function
-         */
-        @Override
-        public float noise(float x, float y, float z) {
-            float result = other.noise(x, y, z);
-
-            float workingX = x;
-            float workingY = y;
-            float workingZ = z;
-            for (int i = 1; i < getOctaves(); i++) {
-                workingX *= Math.pow(2, i) * Math.abs(result);
-                workingY *= Math.pow(2, i) * Math.abs(result);
-                workingZ *= Math.pow(2, i) * Math.abs(result);
-                result += Math.abs(other.noise(workingX, workingY, workingZ)) * (1f / Math.pow(2, i));
-
-            }
-
-            return result;// * scale;
-        }
-
-        private static float computeScale(float[] spectralWeights) {
-            float sum = 0;
-            for (float weight : spectralWeights) {
-                sum += weight;
-            }
-            return 1.0f / sum;
-        }
-
-        /**
-         * @param octaves the number of octaves used for computation
-         */
-        public void setOctaves(int octaves) {
-            this.octaves = octaves;
-            updateWeights();
-        }
-
-        /**
-         * @return the number of octaves
-         */
-        public int getOctaves() {
-            return octaves;
-        }
-
-        /**
-         * Lacunarity is what makes the frequency grow. Each octave
-         * the frequency is multiplied by the lacunarity.
-         *
-         * @return the lacunarity
-         */
-        public double getLacunarity() {
-            return this.lacunarity;
-        }
-
-        /**
-         * Lacunarity is what makes the frequency grow. Each octave
-         * the frequency is multiplied by the lacunarity.
-         *
-         * @param lacunarity the lacunarity
-         */
-        public void setLacunarity(double lacunarity) {
-            this.lacunarity = lacunarity;
-        }
-
-        /**
-         * Persistence is what makes the amplitude shrink.
-         * More precicely the amplitude of octave i = lacunarity^(-persistence * i)
-         *
-         * @return the persistance
-         */
-        public double getPersistance() {
-            return this.persistence;
-        }
-
-        /**
-         * Persistence is what makes the amplitude shrink.
-         * More precisely the amplitude of octave i = lacunarity^(-persistence * i)
-         *
-         * @param persistence the persistence to set
-         */
-        public void setPersistence(double persistence) {
-            this.persistence = persistence;
-            updateWeights();
-        }
-
-        private void updateWeights() {
-            // recompute weights eagerly
-            spectralWeights = new float[octaves];
-
-            for (int i = 0; i < octaves; i++) {
-                spectralWeights[i] = (float) Math.pow(lacunarity, -persistence * i);
-            }
-
-            scale = computeScale(spectralWeights);
-        }
-    }
-
 }

--- a/src/main/java/org/terasology/caves/CaveFacetProvider.java
+++ b/src/main/java/org/terasology/caves/CaveFacetProvider.java
@@ -19,35 +19,34 @@ import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.rendering.nui.properties.Range;
-import org.terasology.utilities.procedural.AbstractNoise;
-import org.terasology.utilities.procedural.BrownianNoise3D;
-import org.terasology.utilities.procedural.Noise3D;
+import org.terasology.utilities.procedural.BrownianNoise;
+import org.terasology.utilities.procedural.Noise;
 import org.terasology.utilities.procedural.SimplexNoise;
-import org.terasology.utilities.procedural.SubSampledNoise3D;
+import org.terasology.utilities.procedural.SubSampledNoise;
 import org.terasology.world.generation.ConfigurableFacetProvider;
 import org.terasology.world.generation.Facet;
 import org.terasology.world.generation.FacetProviderPlugin;
 import org.terasology.world.generation.GeneratingRegion;
 import org.terasology.world.generation.Produces;
-import org.terasology.world.generation.Requires;
-import org.terasology.world.generation.facets.SurfaceHeightFacet;
 import org.terasology.world.generator.plugin.RegisterPlugin;
 
+/**
+ * Generates 2 independent noise functions, then puts caves where both of them are
+ * close to 0. For topological reasons, this tends to produce caves in the shape
+ * of continuous lines, which can't have dead ends, but may loop around and have
+ * junctions (of an even number of tunnels).
+ */
 @RegisterPlugin
 @Produces(CaveFacet.class)
-@Requires(@Facet(SurfaceHeightFacet.class))
 public class CaveFacetProvider implements FacetProviderPlugin {
 
-    SubSampledNoise3D[] caveNoise = new SubSampledNoise3D[2];
+    SubSampledNoise[] caveNoise = new SubSampledNoise[2];
 
     @Override
     public void setSeed(long seed) {
         for(int i=0; i<2; i++) {
-            Noise3D pNoise = new SimplexNoise(seed + 2 + i);
-            BrownianNoise3D bNoise = new BrownianNoise3D(pNoise, 3);
-            bNoise.setPersistence(1.0);
-            SubSampledNoise3D sNoise = new SubSampledNoise3D(bNoise, new Vector3f(0.01f, 0.01f, 0.01f), 4);
-            caveNoise[i] = sNoise;
+            BrownianNoise baseNoise = new BrownianNoise(new SimplexNoise(seed + 2 + i), 4);
+            caveNoise[i] = new SubSampledNoise(baseNoise, new Vector3f(0.006f, 0.006f, 0.006f), 4);
         }
     }
 
@@ -60,10 +59,11 @@ public class CaveFacetProvider implements FacetProviderPlugin {
         float[][] caveNoiseValues = new float[][]{caveNoise[0].noise(facet.getWorldRegion()),caveNoise[1].noise(facet.getWorldRegion())};
 
         for (Vector3i pos : region.getRegion()) {
+            float frequencyReduction = (float)Math.min(0.3,Math.max(0,(100+pos.y)/400.0)); //0: no reduction, 0.7: pretty much no caves. Also somewhat increases the tendency of caves to loop rather than continuing indefinitely.
             int i = facet.getWorldIndex(pos);
-            float noiseValue = (float) Math.hypot(caveNoiseValues[0][i], caveNoiseValues[1][i]);
+            float noiseValue = (float) Math.hypot(caveNoiseValues[0][i], caveNoiseValues[1][i]+frequencyReduction);
 
-            facet.setWorld(pos, noiseValue < 0.2);
+            facet.setWorld(pos, noiseValue < 0.08);
         }
 
         region.setRegionFacet(CaveFacet.class, facet);

--- a/src/main/java/org/terasology/caves/CaveFacetProvider.java
+++ b/src/main/java/org/terasology/caves/CaveFacetProvider.java
@@ -37,7 +37,6 @@ import org.terasology.world.generator.plugin.RegisterPlugin;
 @Produces(CaveFacet.class)
 @Requires(@Facet(SurfaceHeightFacet.class))
 public class CaveFacetProvider implements FacetProviderPlugin {
-    private CaveFacetProviderConfiguration configuration = new CaveFacetProviderConfiguration();
 
     SubSampledNoise3D[] caveNoise = new SubSampledNoise3D[2];
 


### PR DESCRIPTION
Make caves more biased towards continuing as channels rather than coincidentally connecting together as blobs. Overall reduces the amount of the world that is cave, while keeping them connected. Reduces the amount of branching.

The original algorithm wasn't really suitable for generating a branching linear structure, so I just completely replaced it. The new algorithm generates a noise function with a 2D output (or equivalently, 2 independent noise functions), then puts caves wherever that is near 0. Because of topological constraints, it's practically impossible for a cave to actually end. It could loop back on itself, covering the same volume each time, or become too thin to be navigable (or, in theory, too thin to contain any blocks), but both of these cases are very unlikely. It would be possible to artificially add back in the possibility of dead ends, with configurable likelihood, if people prefer.

I think the decreased amount of caves near the surface in the previous version may have been a hack to avoid having the ground full of holes while keeping the cave density lower down high enough that they tend to be connected. As this algorithm naturally gives connectivity, I don't think that's necessary in this case.

There's still some tweaking to be done of the parameters, which I'd appreciate feedback on. As the original configuration options didn't really match the new algorithm, I just removed them all, but if there are things people think ought to be configurable, something could be added back in.