### PR TITLE
fix: Make less assumptions on the relative sizes of facet borders.

### DIFF
--- a/src/main/java/org/terasology/caves/CaveToSurfaceProvider.java
+++ b/src/main/java/org/terasology/caves/CaveToSurfaceProvider.java
@@ -102,7 +102,7 @@ public class CaveToSurfaceProvider implements FacetProviderPlugin {
                     new Vector3i(surface).subZ(1),
                     new Vector3i(surface).addZ(1)
                 }) {
-                    while (!cavePositions.contains(adjacent) && adjacent.y <= densityFacet.getWorldRegion().maxY() && densityFacet.getWorld(adjacent) > 0) {
+                    while (!cavePositions.contains(adjacent) && densityFacet.getWorldRegion().encompasses(adjacent) && densityFacet.getWorld(adjacent) > 0) {
                         adjacent.addY(1);
                     }
                     // Only continue if the selected position is actually in a cave, rather than on the surface or above the selected region.


### PR DESCRIPTION
Avoid an exception when the SurfacesFacet and the DensityFacet have the same horizontal border size. This is necessary for https://github.com/MovingBlocks/Terasology/pull/4313 to work.