### PR TITLE
perf: improve performance of facet providers

### DIFF
--- a/src/main/java/org/terasology/caves/CaveToSurfaceProvider.java
+++ b/src/main/java/org/terasology/caves/CaveToSurfaceProvider.java
@@ -17,7 +17,6 @@ import org.terasology.world.generation.facets.SeaLevelFacet;
 import org.terasology.world.generation.facets.SurfacesFacet;
 import org.terasology.world.generator.plugin.RegisterPlugin;
 
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -56,6 +55,7 @@ public class CaveToSurfaceProvider implements FacetProviderPlugin {
             }
         }
 
+        Vector3i belowPos = new Vector3i();
         // Ensure that the ocean can't immediately fall into a cave.
         for (Vector3ic pos : densityFacet.getWorldRegion()) {
             if (densityFacet.getWorld(pos) <= 0) {
@@ -66,7 +66,7 @@ public class CaveToSurfaceProvider implements FacetProviderPlugin {
                 if (pos.y() <= seaLevel.getSeaLevel() + 1) {
                     for (int x = -1; x <= 1; x++) {
                         for (int z = -1; z <= 1; z++) {
-                            Vector3i belowPos = new Vector3i(pos.x() + x, pos.y() - 1, pos.z() + z);
+                            belowPos.set(pos.x() + x, pos.y() - 1, pos.z() + z);
                             if (cavePositions.contains(belowPos)) {
                                 cavePositions.remove(belowPos);
                                 caveFacet.setWorld(belowPos, false);

--- a/src/main/java/org/terasology/caves/CaveToSurfaceProvider.java
+++ b/src/main/java/org/terasology/caves/CaveToSurfaceProvider.java
@@ -3,6 +3,7 @@
 
 package org.terasology.caves;
 
+import com.google.common.collect.Sets;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.terasology.world.generation.Facet;
@@ -47,7 +48,7 @@ public class CaveToSurfaceProvider implements FacetProviderPlugin {
         SurfacesFacet surfacesFacet = region.getRegionFacet(SurfacesFacet.class);
         SeaLevelFacet seaLevel = region.getRegionFacet(SeaLevelFacet.class);
 
-        Set<Vector3ic> cavePositions = new HashSet();
+        Set<Vector3ic> cavePositions = Sets.newHashSetWithExpectedSize(caveFacet.getWorldRegion().getSizeX() * caveFacet.getWorldRegion().getSizeZ());
 
         for (Vector3ic pos : caveFacet.getWorldRegion()) {
             if (caveFacet.getWorld(pos) && densityFacet.getWorldRegion().contains(pos) && surfacesFacet.getWorldRegion().contains(pos)) {
@@ -77,7 +78,7 @@ public class CaveToSurfaceProvider implements FacetProviderPlugin {
         }
 
         // Mark any cave floors exposed to the sky as surface.
-        Set<Vector3i> newSurfaces = new HashSet<>();
+        Set<Vector3i> newSurfaces = Sets.newHashSet();
         for (Vector3ic pos : cavePositions) {
             if (surfacesFacet.getWorld(pos)) {
                 surfacesFacet.setWorld(pos, false);
@@ -97,9 +98,11 @@ public class CaveToSurfaceProvider implements FacetProviderPlugin {
         Vector3i a3 = new Vector3i();
         Vector3i a4 = new Vector3i();
 
+
+        Set<Vector3i> newerSurfaces = Sets.newHashSetWithExpectedSize(newSurfaces.size());
         // Mark cave floors near to those exposed to the sky as surface.
         for (int i = 0; i < SURFACE_SPREAD; i++) {
-            Set<Vector3i> newerSurfaces = new HashSet<>();
+            newerSurfaces.clear();
             for (Vector3i surface : newSurfaces) {
                 for (Vector3i adjacent : new Vector3i[]{
                         a1.set(surface).sub(1, 0, 0),
@@ -128,7 +131,9 @@ public class CaveToSurfaceProvider implements FacetProviderPlugin {
                     }
                 }
             }
+            Set<Vector3i> temp = newSurfaces;
             newSurfaces = newerSurfaces;
+            newerSurfaces = temp;
         }
     }
 }

--- a/src/main/java/org/terasology/caves/CaveToSurfaceProvider.java
+++ b/src/main/java/org/terasology/caves/CaveToSurfaceProvider.java
@@ -47,7 +47,7 @@ public class CaveToSurfaceProvider implements FacetProviderPlugin {
         SurfacesFacet surfacesFacet = region.getRegionFacet(SurfacesFacet.class);
         SeaLevelFacet seaLevel = region.getRegionFacet(SeaLevelFacet.class);
 
-        Set<Vector3ic> cavePositions = Sets.newHashSetWithExpectedSize(0.33f * caveFacet.getWorldRegion().volume());
+        Set<Vector3ic> cavePositions = Sets.newHashSetWithExpectedSize((int) (0.33f * caveFacet.getWorldRegion().volume()));
 
         for (Vector3ic pos : caveFacet.getWorldRegion()) {
             if (caveFacet.getWorld(pos) && densityFacet.getWorldRegion().contains(pos) && surfacesFacet.getWorldRegion().contains(pos)) {

--- a/src/main/java/org/terasology/caves/CaveToSurfaceProvider.java
+++ b/src/main/java/org/terasology/caves/CaveToSurfaceProvider.java
@@ -48,7 +48,7 @@ public class CaveToSurfaceProvider implements FacetProviderPlugin {
         SurfacesFacet surfacesFacet = region.getRegionFacet(SurfacesFacet.class);
         SeaLevelFacet seaLevel = region.getRegionFacet(SeaLevelFacet.class);
 
-        Set<Vector3ic> cavePositions = Sets.newHashSetWithExpectedSize(caveFacet.getWorldRegion().getSizeX() * caveFacet.getWorldRegion().getSizeZ());
+        Set<Vector3ic> cavePositions = Sets.newHashSetWithExpectedSize(0.33f * caveFacet.getWorldRegion().volume());
 
         for (Vector3ic pos : caveFacet.getWorldRegion()) {
             if (caveFacet.getWorld(pos) && densityFacet.getWorldRegion().contains(pos) && surfacesFacet.getWorldRegion().contains(pos)) {


### PR DESCRIPTION
here are some minor improvements to improve cave generation. A Hashset does not seem ideal in this case especially when we can take advantage of locality. Math.hypot seems really expensive what I was looking at and reduced some of GC for that hashset that was used.  