### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/caves/CaveObjectProvider.java
+++ b/src/main/java/org/terasology/caves/CaveObjectProvider.java
@@ -94,14 +94,14 @@ public class CaveObjectProvider implements ConfigurableFacetProvider, FacetProvi
         this.configuration = (CaveObjectConfiguration) configuration;
     }
 
-    private static class CaveObjectConfiguration implements Component<CaveObjectConfiguration> {
+    public static class CaveObjectConfiguration implements Component<CaveObjectConfiguration> {
         @Range(min = 0, max = 1.0f, increment = 0.01f, precision = 2,
                 description = "Define the overall amount of objects")
-        private float density = 0.06f;
+        public float density = 0.06f;
 
         @Range(min = 0, max = 250f, increment = 1f, precision = 0,
                 description = "The minimum distance below the surface before objects start to appear")
-        private float minDepth = 5f;
+        public float minDepth = 5f;
 
         @Override
         public void copyFrom(CaveObjectConfiguration other) {


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191